### PR TITLE
use full year on multi-parameter date constructor

### DIFF
--- a/datetime-picker-mixin.html
+++ b/datetime-picker-mixin.html
@@ -148,7 +148,9 @@
         if (super.confirm) {
           super.confirm();
         } else {
-          this._setDate(new Date(this.year, this.month - 1, this.day, this.hours, this.minutes, this.seconds, this.milliseconds));
+          var d = new Date(this.year, this.month - 1, this.day, this.hours, this.minutes, this.seconds, this.milliseconds);
+          d.setFullYear(this.year);
+          this._setDate(d);
         }
         if (this.close) {
           this.close();


### PR DESCRIPTION
Use full year after multi-parameter Date constructor, which is being used by the mixins and considers a one- or two-digit value as a year since 1900. Fixes problem reported in fooloomanzoo/property-mixins#1.